### PR TITLE
use C++11 ::std::isnan check instead of v!=v, so it works with Visual…

### DIFF
--- a/include/cppad/cg/nan.hpp
+++ b/include/cppad/cg/nan.hpp
@@ -26,9 +26,13 @@ inline bool isnan(const cg::CG<Base> &s) {
     } else {
         // a parameter
         const Base& v = s.getValue();
-        return (v != v);
+        if constexpr (std::is_floating_point<Base>::value) {
+            return ::std::isnan(v);
+        }
+        else {
+            return (v != v);
+        }
     }
-}
 
 } // END CppAD namespace
 


### PR DESCRIPTION
… Studio in Fastmath  (/fp:fast) mode

In our case, the check v!=v failed for nan, due to usage of /fp:fast. Using std::isnan is more robust in this case. 
Hope it compiles cross-platform.