### PR TITLE
Fix clang build with CppAD >= 2024

### DIFF
--- a/include/cppad/cg/base_double.hpp
+++ b/include/cppad/cg/base_double.hpp
@@ -20,29 +20,7 @@ namespace CppAD {
 /**
  * Specialization of the numeric_limits for doubles
  */
-template <>
-class numeric_limits<cg::CG<double> > {
-public:
-
-    static cg::CG<double> epsilon() {
-        return std::numeric_limits<double>::epsilon();
-    }
-
-    static cg::CG<double> min() {
-        return (std::numeric_limits<double>::min)();
-    }
-
-    static cg::CG<double> max() {
-        return (std::numeric_limits<double>::max)();
-    }
-
-    static cg::CG<double> quiet_NaN() {
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-
-    static const int digits10 
-        = std::numeric_limits<double>::digits10;
-};
+CPPAD_NUMERIC_LIMITS(double, cg::CG<double>)
 
 /**
  * Specialization of the machine epsilon for CG<double>

--- a/include/cppad/cg/base_float.hpp
+++ b/include/cppad/cg/base_float.hpp
@@ -20,29 +20,7 @@ namespace CppAD {
 /**
  * Specialization of the numeric_limits for floats
  */
-template <>
-class numeric_limits<cg::CG<float> > {
-public:
-
-    static cg::CG<float> epsilon() {
-        return std::numeric_limits<float>::epsilon();
-    }
-
-    static cg::CG<float> min() {
-        return std::numeric_limits<float>::min();
-    }
-
-    static cg::CG<float> max() {
-        return std::numeric_limits<float>::max();
-    }
-
-    static cg::CG<float> quiet_NaN() {
-        return std::numeric_limits<float>::quiet_NaN();
-    }
-
-    static const int digits10 
-        = std::numeric_limits<float>::digits10;
-};
+CPPAD_NUMERIC_LIMITS(float, cg::CG<float>)
 
 /**
  * Specialization of the machine epsilon for CG<float>


### PR DESCRIPTION
Hello,

CppAD 2024 add a `max_digits10` member to `CppAD::numeric_limits`.
This member is not defined in CppADCodeGen and this create compilation issue with clang based compiler.
    
To avoid future issue, we use `CPPAD_NUMERIC_LIMITS` macro that will ensure we always have an up to date version of `CppAD::numeric_limits`.
    
See [CppAD#206](https://github.com/coin-or/CppAD/issues/206).

#87 should be merged before merging this PR.