### PR TITLE
CMake: look for system gtest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,19 +20,22 @@ SET(CMAKE_BUILD_TYPE DEBUG)
 ################################################################################
 # download and compile GTest
 ################################################################################
-INCLUDE(ExternalProject)
+find_package(GTest)
+if(NOT GTEST_FOUND)
+    INCLUDE(ExternalProject)
 
-# Download from GitHub
-INCLUDE(FetchContent)
-FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip)
+    # Download from GitHub
+    INCLUDE(FetchContent)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip)
 
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-SET(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    SET(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
 
-INCLUDE(GoogleTest)
+    INCLUDE(GoogleTest)
+endif()
 
 ################################################################################
 # add gtest dependency


### PR DESCRIPTION
Hi,

This add a simple test checking if google test is already available on the system.

Because when this is the case, there is no point fetching it from github, especially since this require a working network access and might fail.

On my current use case, the Nix package manager build softwares in a sandbox without network access to ensure their reproducibility, so this it is required to have all dependencies available before the configuration of one software.

